### PR TITLE
Improve attribute and variable naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # CHANGELOG
 
 ## HEAD
+* Change html namespace default from `hill-layout` to `hill-helper`
+* Fix dublicate css output for box and responsive stuff
+* Simplify documentation of `_config.scss`
+* Rename/Merge `$hill-layout-attribute-name` and `$hill-text-attribute-name` to `$hill-html-namespace`
+* Rename `$hill-layout-boxes` to `$hill-box-sizes`
+* Rename `$hill-box-sizes-space` to `$hill-box-space`
+* Rename `$hill-box-sizes-space` to `$hill-box-space`
+* Rename `$hill-layout-space` to `$hill-general-space`
+* Rename `$hill-layout-space-multiplier` to `$hill-general-space-multiplier`
+* Rename `$hill-layout-breakpoints` to `$hill-responsive-breakpoints`
+* Add `root` to `$hill-text-sizes` to configure a custom root font-size
+* Rename `$hill-layout-css-general` to `$hill-general-css-output`
+* Rename `$hill-layout-css-box` to `$hill-box-css-output`
+* Rename `$hill-layout-css-responsive` to `$hill-responsive-css-output`
+* Rename `$hill-text-css-helpers` to `$hill-text-css-output`
+* Rename `$hill-layers` to `$hill-layer-order`
 * Update file dependencies of the new structure
 * Rename `_helpers.spec.scss` to `functions.spec.scss`
 * Rename `_utilities.spec.scss` to `_mixins.spec.scss`
@@ -28,7 +44,6 @@
 * Move `hill.css` and `test-results.css` to `dist` folder
 * Unittests for layers() module
 * Add `$hill-layout-space-multiplier` variable to configure how many spacing multiplier are needed for a project, for example `2x`, `3x` and so on.
-* `$hill-text-root` Create SASS variable to configure a custom root font-size
 * Make hill extendable and configurable
 * Add Jasmine-style BDD testing for SASS with Bootcamp
 * Rename main entrypoint layout.scss to hill.scss

--- a/lib/_config.scss
+++ b/lib/_config.scss
@@ -5,46 +5,38 @@
 
 
 
-// Attribute name for html -> <div hill-layout="..."></div>
-$hill-layout-attribute-name: hill-layout !default;
+// Attribute name for html
+$hill-html-namespace: hill-helper !default;
 
-// Attribute name for html -> <a hill-text="..."></a>
-$hill-text-attribute-name: hill-text !default;
-
-// Box width sizes for usage in html -> .."box-1/2"..
-$hill-layout-boxes: (
+// Box width sizes for usage in html
+$hill-box-sizes: (
     '1/4',
     '1/2',
     '3/4',
     '1/1') !default;
 
-// Box space definition. Set to 0%, if you want to disable spaces between boxes.
-$hill-layout-boxes-space: 2% !default;
+// Space definition between boxes. Set to 0%,
+// if you want to disable spaces.
+$hill-box-space: 2% !default;
 
-// Space definition for usage in html -> .."space-right"..
-// Percentage and rem values can be defined here too.
-$hill-layout-space: 20px !default;
+// General space definition
+$hill-general-space: 20px !default;
 
-// Multiplier of `$hill-layout-space`
-// For Example `space-bottom-2x`
-// If it has a value of 3, it means that
-// `space-bottom`, `space-bottom-2x` and `space-bottom-3x`
-// helper attributes are available in html.
-$hill-layout-space-multiplier: 2 !default;
+// Multiplier of `$hill-general-space`
+// @example
+// 3 -> `space-bottom`, `space-bottom-2x`, `space-bottom-3x`
+$hill-general-space-multiplier: 2 !default;
 
-// Breakpoints for html -> .."device-small-1/2".. and the sass helpers for example
-// the 'deviceIs' helper.
-$hill-layout-breakpoints: (
+// Breakpoints for responsive mechanism
+$hill-responsive-breakpoints: (
     small:  480px,
     medium: 992px,
     large:  1280px
 ) !default;
 
-// Root Fontsize for Rem calculation
-$hill-text-root: 16px !default;
-
-// Text sizes for html -> .."small-2x".. and the 'textIs' helper
+// Text sizes
 $hill-text-sizes: (
+    root:     16px,
     base:     1rem,
     small-2x: 0.9rem,
     small-3x: 0.8rem,
@@ -52,34 +44,33 @@ $hill-text-sizes: (
     large-3x: 1.4rem
 ) !default;
 
-
-// -------------------------------------------------------- Output Configuration
-// To configure the output css, overwrite these variables in your custom
-// settings file. For more check out the demo.
-
-// Layout helpers.
-// Example -> <div hill-layout="space-right"></div>
-$hill-layout-css-general: true !default;
-
-// General helpers like box width based on '$hill-layout-boxes', which can be
-// used in HTML.
-// Example -> <div hill-layout="box-1/2"></div>
-$hill-layout-css-box: true !default;
-
-// Breakpoint CSS classes for usage in HTML
-// Example -> <div hill-layout="device-small-1/2 device-medium-2/3"></div>
-$hill-layout-css-responsive: false !default;
-
-// Text helpers like 'right, left'.
-// Example -> <div hill-text="right"></div>
-$hill-text-css-helpers: false !default;
-
 //
 // Definition of z-index layers. Can be use to manage layer order.
 // Top item has the highest z-index value and bottom item the lowest.
-// Check "layer" function in "_helpers.scss" for more information
 //
-$hill-layers: (
+$hill-layer-order: (
     'highest',
     'lowest'
 ) !default;
+
+
+
+//
+// HINT: The next configuration part generate css output.
+//       To configure the output css, overwrite these variables in
+//       your custom settings file. For more check out the demo.
+//
+
+
+
+// General output for helpers like spaces.
+$hill-general-css-output: true !default;
+
+// Box width output for layouting
+$hill-box-css-output: true !default;
+
+// Breakpoint output for responsive design
+$hill-responsive-css-output: true !default;
+
+// Text helpers output like right, left
+$hill-text-css-output: true !default;

--- a/lib/_functions.scss
+++ b/lib/_functions.scss
@@ -28,7 +28,7 @@
 // @param {String} $base Optional rem value to get the right scope
 // @return {String} rem value
 //
-@function rem($pixel, $base: $hill-text-root) {
+@function rem($pixel, $base: map-get($hill-text-sizes, 'root')) {
     @return stripUnit($pixel) / stripUnit($base) * 1rem;
 }
 
@@ -48,7 +48,7 @@
 //        z-index: @layer('page');
 //    }
 //
-//    $hill-layers: (
+//    $hill-layer-order: (
 //        'modal',
 //        'page'
 //    );
@@ -56,7 +56,7 @@
 //    .modal -> z-index: 2
 //    .page -> z-index: 1
 //
-//    $hill-layers: (
+//    $hill-layer-order: (
 //        'highest',
 //        'center',
 //        'lowest'
@@ -67,7 +67,7 @@
 //    .lowest -> z-index: 1
 //
 @function layer($alias) {
-    @return ((length($hill-layers) - index($hill-layers, $alias)) + 1);
+    @return ((length($hill-layer-order) - index($hill-layer-order, $alias)) + 1);
 }
 
 

--- a/lib/_mixins.scss
+++ b/lib/_mixins.scss
@@ -3,7 +3,7 @@
 // @param  {String} $device The device breakpoint definition for the media query
 // @return {CSS}            CSS contents with inside of
 //                          the given media query
-// @Example
+// @example
 //           // Simple MediaQuery for small screens only
 //           .example {
 //               color: blue;
@@ -14,16 +14,16 @@
 //           }
 //
 @mixin deviceIs ($device) {
-    @if global-variable-exists(hill-layout-breakpoints) {
+    @if global-variable-exists(hill-responsive-breakpoints) {
         // Defaults for first parameter and condition
-        $breakpoint: map-get($hill-layout-breakpoints, $device);
+        $breakpoint: map-get($hill-responsive-breakpoints, $device);
 
-        @if (mapGetFirstKey($hill-layout-breakpoints) == $device) {
+        @if (mapGetFirstKey($hill-responsive-breakpoints) == $device) {
             @media (max-width: #{$breakpoint}) {
                 @content;
             }
         } @else {
-            @media (min-width: #{mapGetPrevious($hill-layout-breakpoints, $device) + 1}) and
+            @media (min-width: #{mapGetPrevious($hill-responsive-breakpoints, $device) + 1}) and
                    (max-width: #{$breakpoint}) {
                 @content;
             }
@@ -47,8 +47,8 @@
 //           }
 //
 @mixin deviceMin ($device) {
-    @if global-variable-exists(hill-layout-breakpoints) {
-        @media (min-width: #{map-get($hill-layout-breakpoints, $device) + 1}) {
+    @if global-variable-exists(hill-responsive-breakpoints) {
+        @media (min-width: #{map-get($hill-responsive-breakpoints, $device) + 1}) {
             @content;
         }
     }
@@ -70,8 +70,8 @@
 //           }
 //
 @mixin deviceMax ($device) {
-    @if global-variable-exists(hill-layout-breakpoints) {
-        @media (max-width: #{map-get($hill-layout-breakpoints, $device)}) {
+    @if global-variable-exists(hill-responsive-breakpoints) {
+        @media (max-width: #{map-get($hill-responsive-breakpoints, $device)}) {
             @content;
         }
     }
@@ -94,9 +94,9 @@
 //           }
 //
 @mixin deviceBetween ($deviceMin, $deviceMax) {
-    @if global-variable-exists(hill-layout-breakpoints) {
-        @media (min-width: #{map-get($hill-layout-breakpoints, $deviceMin) + 1})
-            and (max-width: #{map-get($hill-layout-breakpoints, $deviceMax)}) {
+    @if global-variable-exists(hill-responsive-breakpoints) {
+        @media (min-width: #{map-get($hill-responsive-breakpoints, $deviceMin) + 1})
+            and (max-width: #{map-get($hill-responsive-breakpoints, $deviceMax)}) {
             @content;
         }
     }

--- a/lib/core/_box.scss
+++ b/lib/core/_box.scss
@@ -5,13 +5,13 @@
 //
 // Generates boxes and rows
 //
-@if ($hill-layout-css-box) {
+@if ($hill-box-css-output) {
     //
     // Generates box width attributes
     // -> box-1/2, box-1/3 ...
     //
-    @each $width in $hill-layout-boxes {
-        [#{$hill-layout-attribute-name}*="box-#{$width}"] {
+    @each $width in $hill-box-sizes {
+        [#{$hill-html-namespace}*="box-#{$width}"] {
             width: fractionToPercent($width);
         }
     }
@@ -19,20 +19,28 @@
     //
     // Generates box row to float boxes inside
     //
-    [#{$hill-layout-attribute-name}*="row"]  {
-        & > [#{$hill-layout-attribute-name}*="box-"] {
-            @extend %_floatLeft;
+    [#{$hill-html-namespace}*="row"]  {
+        & > [#{$hill-html-namespace}*="box-"] {
+            float: left;
         }
 
-        @extend %_clearfix;
+        &:before,
+        &:after {
+            content: " ";
+            display: table;
+        }
+
+        &:after {
+            clear: both;
+        }
     }
 
-    @if(stripUnit($hill-layout-boxes-space) > 0) {
-        [#{$hill-layout-attribute-name}*="box-"] {
+    @if(stripUnit($hill-box-space) > 0) {
+        [#{$hill-html-namespace}*="box-"] {
             display: block;
 
             &:not(:last-child) {
-                margin-right: #{$hill-layout-boxes-space};
+                margin-right: #{$hill-box-space};
             }
         }
     }

--- a/lib/core/_general.scss
+++ b/lib/core/_general.scss
@@ -2,22 +2,32 @@
 
 
 
-@if ($hill-layout-css-general) {
-    @for $index from 1 through $hill-layout-space-multiplier {
+@if ($hill-general-css-output) {
+    @for $index from 1 through $hill-general-space-multiplier {
         @if $index > 1 {
             $multiplier: "-#{$index}x";
         } @else {
             $multiplier: '';
         }
 
-        [#{$hill-layout-attribute-name}*="space-top#{$multiplier}"]       { margin-top:    #{$hill-layout-space * $index}; }
-        [#{$hill-layout-attribute-name}*="space-right#{$multiplier}"]     { margin-right:  #{$hill-layout-space * $index}; }
-        [#{$hill-layout-attribute-name}*="space-bottom#{$multiplier}"]    { margin-bottom: #{$hill-layout-space * $index}; }
-        [#{$hill-layout-attribute-name}*="space-left#{$multiplier}"]      { margin-left:   #{$hill-layout-space * $index}; }
+        [#{$hill-html-namespace}*="space-top#{$multiplier}"]       { margin-top:    #{$hill-general-space * $index}; }
+        [#{$hill-html-namespace}*="space-right#{$multiplier}"]     { margin-right:  #{$hill-general-space * $index}; }
+        [#{$hill-html-namespace}*="space-bottom#{$multiplier}"]    { margin-bottom: #{$hill-general-space * $index}; }
+        [#{$hill-html-namespace}*="space-left#{$multiplier}"]      { margin-left:   #{$hill-general-space * $index}; }
     }
 
-    [#{$hill-layout-attribute-name}*="float-left"]     { @extend  %_floatLeft; }
-    [#{$hill-layout-attribute-name}*="float-right"]    { float:   right; }
-    [#{$hill-layout-attribute-name}*="hide"]           { display: none; }
-    [#{$hill-layout-attribute-name}*="clear"]          { @extend  %_clearfix; }
+    [#{$hill-html-namespace}*="float-left"]     { float:   left; }
+    [#{$hill-html-namespace}*="float-right"]    { float:   right; }
+    [#{$hill-html-namespace}*="hide"]           { display: none; }
+    [#{$hill-html-namespace}*="clear"]          {
+        &:before,
+        &:after {
+            content: " ";
+            display: table;
+        }
+
+        &:after {
+            clear: both;
+        }
+    }
 }

--- a/lib/core/_helpers.scss
+++ b/lib/core/_helpers.scss
@@ -3,26 +3,6 @@
 
 
 //
-// Added to reduce css output
-//
-%_floatLeft {
-    float: left;
-}
-
-%_clearfix {
-    &:before,
-    &:after {
-        content: " ";
-        display: table;
-    }
-    &:after {
-        clear: both;
-    }
-}
-
-
-
-//
 // Splits the given fraction string into two parts and returnx
 // them as a map
 // @param  {String} $fraction The fraction string like '1/2'
@@ -73,7 +53,7 @@
         // Fraction in percentage e.g. 1/2 -> 50
         $calcedValue: ((100 / $denominator) * $counter);
 
-        @if($hill-layout-boxes-space > 0) {
+        @if($hill-box-space > 0) {
             // Spaces between boxes.
             // E.g. 3 possible spaces between 4 boxes,
             // because last space is not needed
@@ -81,7 +61,7 @@
 
             // Calculate the correct space size, that we can combine
             // box size with space size to get always 100% total width.
-            $spaceSize: (($hill-layout-boxes-space * $spaceCount) / $denominator);
+            $spaceSize: (($hill-box-space * $spaceCount) / $denominator);
             $result:    #{$calcedValue - $spaceSize};
         } @else {
             $result: #{$calcedValue};

--- a/lib/core/_responsive.scss
+++ b/lib/core/_responsive.scss
@@ -1,29 +1,30 @@
-@import '../functions';
 @import 'helpers';
+@import '../functions';
+@import '../mixins';
 
 
 
 //
 // Generates box breakpoints with relevant width sizes
 //
-@if ($hill-layout-css-responsive) {
-    @if(stripUnit($hill-layout-boxes-space) > 0) {
-        [#{$hill-layout-attribute-name}*="device-"] {
+@if ($hill-responsive-css-output) {
+    @if(stripUnit($hill-box-space) > 0) {
+        [#{$hill-html-namespace}*="device-"] {
             display: block;
 
             &:not(:last-child) {
-                margin-right: #{$hill-layout-boxes-space};
+                margin-right: #{$hill-box-space};
             }
         }
     }
 
-    @each $breakpoint in $hill-layout-breakpoints {
+    @each $breakpoint in $hill-responsive-breakpoints {
         $breakpointName: nth($breakpoint, 1);
 
         // -> box-small-1/2, box-medium-1/2 ...
-        @each $width in $hill-layout-boxes {
+        @each $width in $hill-box-sizes {
             @include deviceIs ($breakpointName) {
-                [#{$hill-layout-attribute-name}*="device-#{$breakpointName}-#{$width}"] {
+                [#{$hill-html-namespace}*="device-#{$breakpointName}-#{$width}"] {
                     width: fractionToPercent($width);
                 }
             };
@@ -31,7 +32,7 @@
 
         // -> box-small-0
         @include deviceIs ($breakpointName) {
-            [#{$hill-layout-attribute-name}*="device-#{$breakpointName}-0"] {
+            [#{$hill-html-namespace}*="device-#{$breakpointName}-0"] {
                 // Tried to exclude this into a placeholder. But this after that
                 // this selector is not rendered inside a media query condition
                 display: none;

--- a/lib/core/_text.scss
+++ b/lib/core/_text.scss
@@ -1,7 +1,7 @@
 //
 // Generates text css attributes
 //
-@if($hill-text-css-helpers) {
+@if($hill-text-css-output) {
     @if (length($hill-text-sizes) > 0) {
         @for $i from 1 through length($hill-text-sizes) {
             $item:  nth($hill-text-sizes, $i);
@@ -9,13 +9,13 @@
             $value: nth($item, 2);
 
             // -> small-2x, large-2x ...
-            [#{$hill-text-attribute-name}*="#{$param}"] {
+            [#{$hill-html-namespace}*="text-#{$param}"] {
                 font-size: $value;
             };
         }
     }
 
-    [#{$hill-text-attribute-name}*="left"]   { text-align:  left;   }
-    [#{$hill-text-attribute-name}*="right"]  { text-align:  right;  }
-    [#{$hill-text-attribute-name}*="center"] { text-align:  center; }
+    [#{$hill-html-namespace}*="text-left"]   { text-align:  left;   }
+    [#{$hill-html-namespace}*="text-right"]  { text-align:  right;  }
+    [#{$hill-html-namespace}*="text-center"] { text-align:  center; }
 }

--- a/tests/specs/_functions.spec.scss
+++ b/tests/specs/_functions.spec.scss
@@ -7,7 +7,7 @@
 @import '../test-helpers';
 
 // Define layers for testing the layer function;
-$hill-layers: (
+$hill-layer-order: (
     'highest',
     'center',
     'lowest'

--- a/tests/specs/_mixins.spec.scss
+++ b/tests/specs/_mixins.spec.scss
@@ -6,7 +6,7 @@
 // Contains helpers for unittesting like should/expect abstractions
 @import '../test-helpers';
 
-$hill-layout-boxes-space: 0%;
+$hill-box-space: 0%;
 
 @include describe("Hill Utilities Functions") {
 


### PR DESCRIPTION
- Fix dublicate css output for box and responsive stuff
- Simplify documentation of `_config.scss`
- Rename/Merge `$hill-layout-attribute-name` and `$hill-text-attribute-name` to `$hill-html-namespace`
- Rename `$hill-layout-boxes` to `$hill-box-sizes`
- Rename `$hill-box-sizes-space` to `$hill-box-space`
- Rename `$hill-box-sizes-space` to `$hill-box-space`
- Rename `$hill-layout-space` to `$hill-general-space`
- Rename `$hill-layout-space-multiplier` to `$hill-general-space-multiplier`
- Rename `$hill-layout-breakpoints` to `$hill-responsive-breakpoints`
- Add `root` to `$hill-text-sizes` to configure a custom root font-size
- Rename `$hill-layout-css-general` to `$hill-general-css-output`
- Rename `$hill-layout-css-box` to `$hill-box-css-output`
- Rename `$hill-layout-css-responsive` to `$hill-responsive-css-output`
- Rename `$hill-text-css-helpers` to `$hill-text-css-output`
- Rename `$hill-layers` to `$hill-layer-order`
