### PR TITLE
Improve variable naming and change html attr default value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # CHANGELOG
 
 ## HEAD
+* Rename `$hill-layout-css-general` to `$hill-layout-general-css-output`
+* Rename `$hill-layout-css-box` to `$hill-layout-box-css-output`
+* Rename `$hill-layout-css-responsive` to `$hill-layout-responsive-css-output`
+* Rename `$hill-text-css-helpers` to `$hill-text-helper-css-output`
+* Rename `$hill-layers` to `$hill-layer-order`
+* Rename `$hill-layout-boxes-space` to `$hill-layout-box-space`
+* Change `$hill-layout-attribute-name` to `$hill-html-prefix` and set default to `hill`
+* Fix duplicate css output for box and responsive stuff
+* Replace `$hill-text-attribute-name` with `$hill-html-prefix`
 * Rename `_helpers.spec.scss` to `functions.spec.scss`
 * Rename `_utilities.spec.scss` to `_mixins.spec.scss`
 * Structure and move logic from `_helpers.scss` and `_utilities.scss` to `_mixins.scss` and `_functions.scss`

--- a/lib/_config.scss
+++ b/lib/_config.scss
@@ -3,11 +3,8 @@
 // your project custom configuration.
 //
 
-// Attribute name for html -> <div hill-layout="..."></div>
-$hill-layout-attribute-name: hill-layout !default;
-
-// Attribute name for html -> <a hill-text="..."></a>
-$hill-text-attribute-name: hill-text !default;
+// Attribute name prefix for html -> <div hill-layout="..."></div>
+$hill-html-prefix: hill !default;
 
 // Box width sizes for usage in html -> .."box-1/2"..
 $hill-layout-boxes: (
@@ -17,7 +14,7 @@ $hill-layout-boxes: (
     '1/1') !default;
 
 // Box space definition. Set to 0%, if you want to disable spaces between boxes.
-$hill-layout-boxes-space: 2% !default;
+$hill-layout-box-space: 2% !default;
 
 // Space definition for usage in html -> .."space-right"..
 // Percentage and rem values can be defined here too.
@@ -56,29 +53,29 @@ $hill-text-sizes: (
 
 // Layout helpers general
 // Example -> <div hill-layout="space-right"></div>
-$hill-layout-css-general: true !default;
+$hill-layout-general-css-output: true !default;
 
 // Layout helpers box
 // like box width based on '$hill-layout-boxes', which can be used in HTML.
 // Example -> <div hill-layout="box-1/2"></div>
-$hill-layout-css-box: true !default;
+$hill-layout-box-css-output: true !default;
 
 // Layout helpers responsive
 // Breakpoint CSS classes for usage in HTML
 // Example -> <div hill-layout="device-small-1/2 device-medium-2/3"></div>
-$hill-layout-css-responsive: false !default;
+$hill-layout-responsive-css-output: false !default;
 
 // Text helpers
 // like 'right, left'.
 // Example -> <div hill-text="right"></div>
-$hill-text-css-helpers: false !default;
+$hill-text-helper-css-output: false !default;
 
 //
 // Definition of z-index layers. Can be use to manage layer order.
 // Top item has the highest z-index value and bottom item the lowest.
 // Check "layer" function in "_helpers.scss" for more information
 //
-$hill-layers: (
+$hill-layer-order: (
     'highest',
     'lowest'
 ) !default;

--- a/lib/_functions.scss
+++ b/lib/_functions.scss
@@ -42,7 +42,7 @@
 //        z-index: @layer('page');
 //    }
 //
-//    $hill-layers: (
+//    $hill-layer-order: (
 //        'modal',
 //        'page'
 //    );
@@ -50,7 +50,7 @@
 //    .modal -> z-index: 2
 //    .page -> z-index: 1
 //
-//    $hill-layers: (
+//    $hill-layer-order: (
 //        'highest',
 //        'center',
 //        'lowest'
@@ -61,5 +61,5 @@
 //    .lowest -> z-index: 1
 //
 @function layer($alias) {
-    @return ((length($hill-layers) - index($hill-layers, $alias)) + 1);
+    @return ((length($hill-layer-order) - index($hill-layer-order, $alias)) + 1);
 }

--- a/lib/core/_helpers.scss
+++ b/lib/core/_helpers.scss
@@ -1,20 +1,6 @@
 @import '../config';
 
 //
-// Added to reduce css output
-//
-%_clearfix {
-    &:before,
-    &:after {
-        content: " ";
-        display: table;
-    }
-    &:after {
-        clear: both;
-    }
-}
-
-//
 // Splits the given fraction string into two parts and returnx
 // them as a map
 // @param  {String} $fraction The fraction string like '1/2'
@@ -63,7 +49,7 @@
         // Fraction in percentage e.g. 1/2 -> 50
         $calcedValue: ((100 / $denominator) * $counter);
 
-        @if($hill-layout-boxes-space > 0) {
+        @if($hill-layout-box-space > 0) {
             // Spaces between boxes.
             // E.g. 3 possible spaces between 4 boxes,
             // because last space is not needed
@@ -71,7 +57,7 @@
 
             // Calculate the correct space size, that we can combine
             // box size with space size to get always 100% total width.
-            $spaceSize: (($hill-layout-boxes-space * $spaceCount) / $denominator);
+            $spaceSize: (($hill-layout-box-space * $spaceCount) / $denominator);
             $result:    #{$calcedValue - $spaceSize};
         } @else {
             $result: #{$calcedValue};

--- a/lib/core/_layout.scss
+++ b/lib/core/_layout.scss
@@ -3,7 +3,7 @@
 //
 // Generates layout helpers
 //
-@if ($hill-layout-css-general) {
+@if ($hill-layout-general-css-output) {
     @for $index from 1 through $hill-layout-space-multiplier {
         @if $index > 1 {
             $multiplier: "-#{$index}x";
@@ -11,29 +11,38 @@
             $multiplier: '';
         }
 
-        [#{$hill-layout-attribute-name}*="space-top#{$multiplier}"]       { margin-top:    #{$hill-layout-space * $index}; }
-        [#{$hill-layout-attribute-name}*="space-right#{$multiplier}"]     { margin-right:  #{$hill-layout-space * $index}; }
-        [#{$hill-layout-attribute-name}*="space-bottom#{$multiplier}"]    { margin-bottom: #{$hill-layout-space * $index}; }
-        [#{$hill-layout-attribute-name}*="space-left#{$multiplier}"]      { margin-left:   #{$hill-layout-space * $index}; }
+        [#{$hill-html-prefix}-layout*="space-top#{$multiplier}"]       { margin-top:    #{$hill-layout-space * $index}; }
+        [#{$hill-html-prefix}-layout*="space-right#{$multiplier}"]     { margin-right:  #{$hill-layout-space * $index}; }
+        [#{$hill-html-prefix}-layout*="space-bottom#{$multiplier}"]    { margin-bottom: #{$hill-layout-space * $index}; }
+        [#{$hill-html-prefix}-layout*="space-left#{$multiplier}"]      { margin-left:   #{$hill-layout-space * $index}; }
     }
 
-    [#{$hill-layout-attribute-name}*="float-left"]     { float:   left; }
-    [#{$hill-layout-attribute-name}*="float-right"]    { float:   right; }
-    [#{$hill-layout-attribute-name}*="hide"]           { display: none; }
-    [#{$hill-layout-attribute-name}*="clear"]          { @extend  %_clearfix; }
+    [#{$hill-html-prefix}-layout*="float-left"]     { float:   left; }
+    [#{$hill-html-prefix}-layout*="float-right"]    { float:   right; }
+    [#{$hill-html-prefix}-layout*="hide"]           { display: none; }
+    [#{$hill-html-prefix}-layout*="clear"]          {
+        &:before,
+        &:after {
+            content: " ";
+            display: table;
+        }
+        &:after {
+            clear: both;
+        }
+    }
 }
 
 //
 // Generates boxes and rows
 //
-@if ($hill-layout-css-box) {
+@if ($hill-layout-box-css-output) {
 
     //
     // Generates box width attributes
     // -> box-1/2, box-1/3 ...
     //
     @each $width in $hill-layout-boxes {
-        [#{$hill-layout-attribute-name}*="box-#{$width}"] {
+        [#{$hill-html-prefix}-layout*="box-#{$width}"] {
             width: fractionToPercent($width);
         }
     }
@@ -41,20 +50,27 @@
     //
     // Generates box row to float boxes inside
     //
-    [#{$hill-layout-attribute-name}*="row"]  {
-        & > [#{$hill-layout-attribute-name}*="box-"] {
+    [#{$hill-html-prefix}-layout*="row"]  {
+        & > [#{$hill-html-prefix}-layout*="box-"] {
             float: left;
         }
 
-        @extend %_clearfix;
+        &:before,
+        &:after {
+            content: " ";
+            display: table;
+        }
+        &:after {
+            clear: both;
+        }
     }
 
-    @if(stripUnit($hill-layout-boxes-space) > 0) {
-        [#{$hill-layout-attribute-name}*="box-"] {
+    @if(stripUnit($hill-layout-box-space) > 0) {
+        [#{$hill-html-prefix}-layout*="box-"] {
             display: block;
 
             &:not(:last-child) {
-                margin-right: #{$hill-layout-boxes-space};
+                margin-right: #{$hill-layout-box-space};
             }
         }
     }
@@ -63,13 +79,13 @@
 //
 // Generates box breakpoints with relevant width sizes
 //
-@if ($hill-layout-css-responsive) {
-    @if(stripUnit($hill-layout-boxes-space) > 0) {
-        [#{$hill-layout-attribute-name}*="device-"] {
+@if ($hill-layout-responsive-css-output) {
+    @if(stripUnit($hill-layout-box-space) > 0) {
+        [#{$hill-html-prefix}-layout*="device-"] {
             display: block;
 
             &:not(:last-child) {
-                margin-right: #{$hill-layout-boxes-space};
+                margin-right: #{$hill-layout-box-space};
             }
         }
     }
@@ -80,7 +96,7 @@
         // -> box-small-1/2, box-medium-1/2 ...
         @each $width in $hill-layout-boxes {
             @include deviceIs ($breakpointName) {
-                [#{$hill-layout-attribute-name}*="device-#{$breakpointName}-#{$width}"] {
+                [#{$hill-html-prefix}-layout*="device-#{$breakpointName}-#{$width}"] {
                     width: fractionToPercent($width);
                 }
             };
@@ -88,7 +104,7 @@
 
         // -> box-small-0
         @include deviceIs ($breakpointName) {
-            [#{$hill-layout-attribute-name}*="device-#{$breakpointName}-0"] {
+            [#{$hill-html-prefix}-layout*="device-#{$breakpointName}-0"] {
 
                 // Tried to exclude this into a placeholder. But this after that
                 // this selector is not rendered inside a media query condition

--- a/lib/core/_text.scss
+++ b/lib/core/_text.scss
@@ -1,7 +1,7 @@
 //
 // Generates text css attributes
 //
-@if($hill-text-css-helpers) {
+@if($hill-text-helper-css-output) {
     @if (length($hill-text-sizes) > 0) {
         @for $i from 1 through length($hill-text-sizes) {
             $item:  nth($hill-text-sizes, $i);
@@ -9,13 +9,13 @@
             $value: nth($item, 2);
 
             // -> small-2x, large-2x ...
-            [#{$hill-text-attribute-name}*="#{$param}"] {
+            [#{$hill-html-prefix}-text*="#{$param}"] {
                 font-size: $value;
             };
         }
     }
 
-    [#{$hill-text-attribute-name}*="left"]   { text-align:  left;   }
-    [#{$hill-text-attribute-name}*="right"]  { text-align:  right;  }
-    [#{$hill-text-attribute-name}*="center"] { text-align:  center; }
+    [#{$hill-html-prefix}-text*="left"]   { text-align:  left;   }
+    [#{$hill-html-prefix}-text*="right"]  { text-align:  right;  }
+    [#{$hill-html-prefix}-text*="center"] { text-align:  center; }
 }

--- a/tests/specs/_functions.spec.scss
+++ b/tests/specs/_functions.spec.scss
@@ -7,7 +7,7 @@
 @import '../test-helpers';
 
 // Define layers for testing the layer function;
-$hill-layers: (
+$hill-layer-order: (
     'highest',
     'center',
     'lowest'

--- a/tests/specs/_mixins.spec.scss
+++ b/tests/specs/_mixins.spec.scss
@@ -6,7 +6,7 @@
 // Contains helpers for unittesting like should/expect abstractions
 @import '../test-helpers';
 
-$hill-layout-boxes-space: 0%;
+$hill-layout-box-space: 0%;
 
 @include describe("Hill Utilities Functions") {
 


### PR DESCRIPTION
- Rename `$hill-layout-css-general` to `$hill-layout-general-css-output`
- Rename `$hill-layout-css-box` to `$hill-layout-box-css-output`
- Rename `$hill-layout-css-responsive` to `$hill-layout-responsive-css-output`
- Rename `$hill-text-css-helpers` to `$hill-text-helper-css-output`
- Rename `$hill-layers` to `$hill-layer-order`
- Rename `$hill-layout-boxes-space` to `$hill-layout-box-space`
- Change `$hill-layout-attribute-name` to `$hill-html-prefix` and set default to `hill`
- Fix dublicate css output for box and responsive stuff
- Replace `$hill-text-attribute-name` with `$hill-html-prefix`
